### PR TITLE
Fix code to have fewer warnings and no errors

### DIFF
--- a/src/ffi/cexport.rs
+++ b/src/ffi/cexport.rs
@@ -14,7 +14,7 @@ use fileio::{AiFileIO};
 /// #aiGetExportFormatDescription() to retrieve a description of an export
 /// format option.
 #[repr(C)]
-struct ExportFormatDesc {
+pub struct ExportFormatDesc {
     /// a short string ID to uniquely identify the export format. Use this ID
     /// string to specify which file format you want to export to when calling
     /// #aiExportScene().  Example: "dae" or "obj"
@@ -41,7 +41,7 @@ struct ExportFormatDesc {
 /// more than one output file for a given #aiScene. See the remarks for
 /// #aiExportDataBlob::name for more information.
 #[repr(C)]
-struct RawExportDataBlob {
+pub struct RawExportDataBlob {
     /// Size of the data in bytes
     pub size: size_t,
 
@@ -157,11 +157,11 @@ extern {
     ///      run the step anyway.
     ///
     /// Returns a status code indicating the result of the export
-    pub fn aiExportScene( scene: *const RawScene,
-                      formatId: *const c_char,
-                      file_name: *const c_char,
-                      preprocessing: c_uint)
-                      -> Return;
+    pub fn aiExportScene(scene: *const RawScene,
+                         format_id: *const c_char,
+                         file_name: *const c_char,
+                         preprocessing: c_uint)
+                         -> Return;
 
 
     /// Releases the memory associated with the given exported data. Use this function to free a data blob

--- a/src/info.rs
+++ b/src/info.rs
@@ -10,7 +10,7 @@ use std::ffi::CStr;
 
 /// Flags for checking how assimp was compiled
 #[derive(Copy, Clone, PartialEq, Eq, Debug)]
-#[repr(C, u32)]
+#[repr(u32)]
 pub enum CompileFlags {
     /// Assimp was compiled as a shared object (Windows: DLL)
     Shared = 0x1,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,6 +25,7 @@ pub use property::TransformUV;
 pub use postprocess::Process;
 pub use importer::Importer;
 
+
 pub mod animation;
 pub mod camera;
 pub mod info;

--- a/src/postprocess.rs
+++ b/src/postprocess.rs
@@ -2,7 +2,7 @@
 
 /// Post processing steps that can be applied once a model is loaded
 #[derive(Clone, Copy)]
-#[repr(C, u32)]
+#[repr(u32)]
 pub enum Process {
     /// Calculates the tangents and bitangents for the imported meshes.
     ///
@@ -443,7 +443,7 @@ pub enum Process {
     /// *  Process::Triangulate
     /// *  Process::GenUVCoords
     /// *  Process::SortByPType
-    Preset_TargetRealtime_Fast = 0x4802b,
+    PresetTargetRealtimeFast = 0x4802b,
 
     /// Default postprocess configuration optimizing the data for real-time
     /// rendering.
@@ -470,7 +470,7 @@ pub enum Process {
     /// *  Process::SortByPType
     /// *  Process::FindDegenerates
     /// *  Process::FindInvalidData
-    Preset_TargetRealtime_Quality = 0x79acb,
+    PresetTargetRealtimeQuality = 0x79acb,
 
     /// Default postprocess configuration optimizing the data for real-time
     /// rendering.
@@ -489,7 +489,7 @@ pub enum Process {
     ///  *  Process::ValidateDataStructure
     ///  *  Process::OptimizeMeshes
     ///  *  Process::Debone
-    Preset_TargetRealtime_MaxQuality = 0x4379ecb,
+    PresetTargetRealtimeMaxQuality = 0x4379ecb,
 }
 
 #[cfg(test)]
@@ -520,7 +520,7 @@ mod test {
                                 Process::FindDegenerates           as u32 |
                                 Process::FindInvalidData           as u32 ;
     pub const PROCESSPRESET_TARGETREALTIME_MAXQUALITY_TEST : u32 =
-                            Process::Preset_TargetRealtime_Quality as u32 |
+                            Process::PresetTargetRealtimeQuality as u32 |
                             Process::FindInstances                 as u32 |
                             Process::ValidateDataStructure         as u32 |
                             Process::OptimizeMeshes                as u32 |
@@ -531,11 +531,11 @@ mod test {
     fn test_show_consts() {
         assert!(Process::ConvertToLeftHanded as u32 ==
                    PROCESS_CONVERTTOLEFTHANDED_TEST);
-        assert!(Process::Preset_TargetRealtime_MaxQuality as u32 ==
+        assert!(Process::PresetTargetRealtimeMaxQuality as u32 ==
                    PROCESSPRESET_TARGETREALTIME_MAXQUALITY_TEST);
-        assert!(Process::Preset_TargetRealtime_Quality as u32 ==
+        assert!(Process::PresetTargetRealtimeQuality as u32 ==
                    PROCESSPRESET_TARGETREALTIME_QUALITY_TEST);
-        assert!(Process::Preset_TargetRealtime_Fast as u32 ==
+        assert!(Process::PresetTargetRealtimeFast as u32 ==
                    PROCESSPRESET_TARGETREALTIME_FAST_TEST);
     }
 }

--- a/src/property.rs
+++ b/src/property.rs
@@ -461,7 +461,7 @@ pub enum Property<'a> {
 
 /// Options for the `Process::TransformUVCoords` post processing step
 #[derive(Copy, Clone, PartialEq, Eq, Debug)]
-#[repr(C, u32)]
+#[repr(u32)]
 pub enum TransformUV {
     /// Scale UV coordinates
     Scaling = 0x1,
@@ -496,7 +496,7 @@ pub enum TransformUV {
 ///
 /// See the documentation to `Process::RemoveComponent` for more details.
 #[derive(Copy, Clone, PartialEq, Eq, Debug)]
-#[repr(C, u32)]
+#[repr(u32)]
 pub enum Component {
     /// Normal vectors
     Normals = 0x2,

--- a/src/scene.rs
+++ b/src/scene.rs
@@ -83,7 +83,7 @@ impl Node {
 
 /// Flags to check the completeness of an imported scene.
 #[derive(Copy, Clone, PartialEq, Eq, Debug)]
-#[repr(C, u32)]
+#[repr(u32)]
 pub enum SceneFlags {
     /// Specifies that the scene data structure that was imported is not
     /// complete.


### PR DESCRIPTION
The only warning left is:

```
warning: found non-foreign-function-safe member in 
struct marked #[repr(C)]: found Rust type `char` in 
foreign module, while `u32` or `libc::wchar_t` should 
be used, #[warn(improper_ctypes)] on by default
```

However, I don't know what's causing this, because in the struct there is only `c_char`:

```rust
#[repr(C)]
#[allow(dead_code)]
pub struct AiFileIO {
    /// Function used to open a new file
    open: FileOpenProc,

    /// Function used to close an existing file
    close: FileCloseProc,

    /// User-defined, opaque data
    user_data: *const c_char,
    //                ^^^^^^ This is not char, it should be okay
}
```